### PR TITLE
move stream into it's own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ $ npm install dataurl
 # Usage
 
 ## dataurl.parse(string)
-Parses a dataurl string. Returns an object with three properties:
+Parses a `dataurl` string. Returns an object with three properties:
 
 * `data` <Buffer>: unencoded data
 * `mimetype` <String>: mimetype of the data, something like `'image/png'`
@@ -16,7 +16,18 @@ Parses a dataurl string. Returns an object with three properties:
 
 If the input string isn't a valid dataURL, returns `false`.
 
-## dataurl.stream(options)
+## dataurl.stringify({mimetype, charset, data})
+
+Converts some data to a `dataurl` string. Options expects up to four properties
+
+* `data` <Buffer>: Required
+* `mimetype` <String>: Required
+* `charset` <String>: Optional
+* `encoded` <Boolean>: Optional, whether to base64 encode the data. Defaults to `true`
+
+`dataurl.format` and `dataurl.convert` are aliases to `dataurl.stringify`
+
+## require('dataurl/stream)(options)
 Creates a Read/Write Stream for encoding data as a DataURL.
 
 Options expects up to three properties:
@@ -37,13 +48,6 @@ fs.createReadStream(pathToSomeImage).pipe(
 ).pipe(process.stderr, {end: false});
 ```
 
-## dataurl.format(options)<br>dataurl.convert(options)
-Converts some data to a dataurl string. Options expects up to four properties
-
-* `data` <Buffer>: Required
-* `mimetype` <String>: Required
-* `charset` <String>: Optional
-* `encoded` <Boolean>: Optional, whether to base64 encode the data. Defaults to `true`
 
 # License
 
@@ -71,3 +75,6 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
+
+
+

--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
-const util = require('util');
-const Stream = require('stream');
-
 const REGEX = {
   dataurl: /data:(.*?)(?:;charset=(.*?))?(;base64)?,(.+)/i,
   newlines: /(\r)|(\n)/g
 }
+
 const MIME_INDEX = 1;
 const CHARSET_INDEX = 2;
 const ENCODED_INDEX = 3;
 const DATA_INDEX = 4;
 
-function dataurl() {}
+var dataurl = exports
 
 function stripNewlines(string) {
   return string.replace(REGEX.newlines, '');
@@ -34,77 +32,14 @@ function makeDataUrlSync(header, data) {
   return (header + Buffer(data).toString('base64'));
 }
 
-function ConvertStream(options) {
-  if (!(this instanceof ConvertStream))
-    return new ConvertStream(options);
-  this.encoded = true && options.encoded !== false;
-  this.charset = options.charset;
-  this.mimetype = options.mimetype;
-  this.header = makeHeader(options);
-  this.headerEmitted = false;
-  this.readable = true;
-  this.writable = true;
-  this._buffer = Buffer(0);
-  this.once('pipe', function (src) {
-    this.pause = src.pause.bind(src);
-    this.resume = src.resume.bind(src);
-  }.bind(this));
-}
-util.inherits(ConvertStream, Stream);
-ConvertStream.prototype._emit = Stream.prototype.emit;
-ConvertStream.prototype.emitData = function emitData(data) {
-  if (!this.headerEmitted) {
-    this.emit('data', this.header);
-    this.headerEmitted = true;
-    this.emitData = this.emit.bind(this, 'data');
-  }
-  this.emit('data', data);
-};
-ConvertStream.prototype.convert = function convert(data) {
-  if (!this.encoded)
-    return data;
-  data = Buffer.concat([this._buffer, Buffer(data)]);
-  if (data.length < 3) {
-    this._buffer = data;
-    return;
-  }
-  const length = data.length;
-  const remainderSize = length % 3;
-  const offset = length - remainderSize;
-  const current = data.slice(0, offset);
-  this._buffer = data.slice(offset);
-  return current.toString('base64');
-};
-ConvertStream.prototype.finish = function finish() {
-  const data = this._buffer;
-  if (!data.length)
-    return;
-  return this.emitData(
-    this.encoded ? data.toString('base64') : data
-  );
-};
-ConvertStream.prototype.write = function write(data) {
-  var output = this.convert(data);
-  if (output)
-    this.emitData(output);
-};
-ConvertStream.prototype.end = function end(data) {
-  if (data)
-    this.write(data);
-  this.finish();
-  this.readable = false;
-  this.writable = false;
-  this.emit('end');
-};
+dataurl.makeHeader = makeHeader
 
-dataurl.stream = function (options) {
-  return new ConvertStream(options);
-};
 dataurl.convert = function (options) {
   const header = makeHeader(options);
   return makeDataUrlSync(header, options.data);
 };
-dataurl.format = dataurl.convert;
+
+dataurl.stringify = dataurl.format = dataurl.convert;
 
 dataurl.parse = function (string) {
   var match;
@@ -125,4 +60,3 @@ dataurl.parse = function (string) {
   }
 };
 
-module.exports = dataurl;

--- a/stream.js
+++ b/stream.js
@@ -1,0 +1,74 @@
+const util = require('util');
+const Stream = require('stream');
+
+const makeHeader = require('./').makeHeader
+
+function ConvertStream(options) {
+  if (!(this instanceof ConvertStream))
+    return new ConvertStream(options);
+  this.encoded = true && options.encoded !== false;
+  this.charset = options.charset;
+  this.mimetype = options.mimetype;
+  this.header = makeHeader(options);
+  this.headerEmitted = false;
+  this.readable = true;
+  this.writable = true;
+  this._buffer = Buffer(0);
+  this.once('pipe', function (src) {
+    this.pause = src.pause.bind(src);
+    this.resume = src.resume.bind(src);
+  }.bind(this));
+}
+
+util.inherits(ConvertStream, Stream);
+
+ConvertStream.prototype._emit = Stream.prototype.emit;
+ConvertStream.prototype.emitData = function emitData(data) {
+  if (!this.headerEmitted) {
+    this.emit('data', this.header);
+    this.headerEmitted = true;
+    this.emitData = this.emit.bind(this, 'data');
+  }
+  this.emit('data', data);
+};
+ConvertStream.prototype.convert = function convert(data) {
+  if (!this.encoded)
+    return data;
+  data = Buffer.concat([this._buffer, Buffer(data)]);
+  if (data.length < 3) {
+    this._buffer = data;
+    return;
+  }
+  const length = data.length;
+  const remainderSize = length % 3;
+  const offset = length - remainderSize;
+  const current = data.slice(0, offset);
+  this._buffer = data.slice(offset);
+  return current.toString('base64');
+};
+ConvertStream.prototype.finish = function finish() {
+  const data = this._buffer;
+  if (!data.length)
+    return;
+  return this.emitData(
+    this.encoded ? data.toString('base64') : data
+  );
+};
+ConvertStream.prototype.write = function write(data) {
+  var output = this.convert(data);
+  if (output)
+    this.emitData(output);
+};
+ConvertStream.prototype.end = function end(data) {
+  if (data)
+    this.write(data);
+  this.finish();
+  this.readable = false;
+  this.writable = false;
+  this.emit('end');
+};
+
+module.exports = function (options) {
+  return new ConvertStream(options);
+};
+

--- a/test/dataurl.test.js
+++ b/test/dataurl.test.js
@@ -3,6 +3,8 @@ const dataurl = require('../');
 const fs = require('fs');
 const resevoir = require('./resevoir');
 
+dataurl.stream = require('../stream')
+
 const TEST_FILE = fs.readFileSync(__dirname + '/reddot.png');
 const TEST_DATAURL = 'data:image/png;base64,'+TEST_FILE.toString('base64');
 


### PR DESCRIPTION
Since you generally get a dataurl in buffered in full, streams are generally overkill.
Also, streams make this 100k larger when browserified.
(since stream3 now have _a lot_ of code, which wasn't true in 2013 when this module was last updated, though it's still 50k, because of Buffer)

So I suggest moving streams into it's own submodule. `require('dataurl').stream` is now at `require('dataurl/stream')`.

Also, I added a `stringify` as an alias to `format`. I think this is easier to remember because it's just like the familiar `JSON.stringify`.

This is a breaking change, so should be published as 1.0.0
